### PR TITLE
Added code for regular lat-lon grid mapping

### DIFF
--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -118,6 +118,10 @@ class LatLon(GridMap):
     self.lat = _var_type('lat',self._latatts,{'lat':tuple(self._latarray)},self._latarray)
     self.gridaxes = [('lat',tuple(self._latarray)),('lon',tuple(self._lonarray))]
     return (self.gridaxes, self.lon, self.lat)
+  # Generic gen_xyll function.
+  def gen_xyll(self):
+    gridaxes, lon, lat = self.gen_ll()
+    return (None, None, gridaxes, lon, lat)
 
 class RotLatLon(GridMap):
   def __init__(self, *args, **kwargs):
@@ -310,12 +314,14 @@ class XYCoords (BufferBase):
             gmapvar = gmap.gen_gmapvar()
             gridmaps[key] = gmapvar.name
             yield gmapvar
-            if grd['grref'].upper() == 'E' : 
-              (xaxis,yaxis,gridaxes,lon,lat) = gmap.gen_xyll() 
+            (xaxis,yaxis,gridaxes,lon,lat) = gmap.gen_xyll()
+            if yaxis is not None and tuple(yaxis.axes.items()) not in coords:
               yield yaxis
+              coords.add(tuple(yaxis.axes.items()))
+            if xaxis is not None and tuple(xaxis.axes.items()) not in coords:
               yield xaxis
-            elif grd['grref'].upper() == 'L' :
-              (gridaxes,lon,lat) = gmap.gen_ll() 
+              coords.add(tuple(xaxis.axes.items()))
+
           else:
             xycoords = gdgaxes(gdid)
             ax = xycoords['ax'].transpose()

--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -290,7 +290,7 @@ class XYCoords (BufferBase):
           # Everything else should be handled by ezqkdef.
           else:
             grd = readGrid(self._meta_funit, var.atts.copy())
-            if grd['grref'].upper() in grrefs :
+            if grd['grref'].upper() not in grrefs :
               gdid = ezqkdef (ni, nj, grtyp, ig1, ig2, ig3, ig4, self._meta_funit)
               ll = gdll(gdid)
         except (TypeError,EzscintError,KeyError):

--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -76,8 +76,13 @@ class GridMap(object):
 # Factory method that creates various types of grid mapping objects
   @classmethod
   def gen_gmap(cls, grd):
+    import numpy as np
     grref = grd['grref'].upper() 
     if grref == 'E' :
+      # Special case: 'E' grid is not actually rotated.
+      if np.allclose(grd['lat0'],grd['rlat0']) and np.allclose(grd['lon0'],grd['rlon0']):
+        return LatLon(grd)
+      # Usual case: 'E' grid is rotated.
       return RotLatLon(grd)
     elif grref == 'L' :
       return LatLon(grd)


### PR DESCRIPTION
The added code creates a grid mapping variable with the standard name "latitude_longitude" for referenced grids based on the grid type 'L' (regular lat-lon). The method gen_ll of the new class LatLon(GridMap) returns the lat and lon coordinates (values in 1D arrays). 

I have tested this version (commit) of the converter with the test file 

2010_Jan_Monday_oarea_CO_1.2x1.2.fst 

and only the metadata changed in the output file, compared to the file generated with the previous commit.