### PR TITLE
Command-line option to remove degenerate "height" axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ optional arguments:
                         Otherwise, the default is to use the date of original
                         analysis, and the forecast length goes in a "forecast"
                         axis.
+  --squash-height       Drop the "height" axis when it is degenerate (0m only)
   --subgrid-axis        For data on supergrids, split the subgrids along a
                         "subgrid" axis. The default is to leave the subgrids
                         stacked together as they are in the RPN file.


### PR DESCRIPTION
This is already done automatically for degenerate pressure axes (0mb values).  This extends the logic to degenerate height axes (0m values).  Not sure if this should be automatic, so adding a command-line option to enable it as needed.

Tested against BTRJ-la70.00nlo-92.00/2014070323_000 in the test suite.