### PR TITLE
Fix masked fields with type X32

### DIFF
--- a/fstd2nc/mixins/array.py
+++ b/fstd2nc/mixins/array.py
@@ -28,7 +28,7 @@ class XArray (BufferBase):
 
   # The interface for getting chunks into dask.
   def _read_chunk (self, rec_id, shape, dtype):
-    return self._fstluk(rec_id)['d'].transpose().reshape(shape).view(dtype)
+    return self._fstluk(rec_id,dtype=dtype)['d'].transpose().reshape(shape)
 
   def to_xarray (self):
     """

--- a/fstd2nc/mixins/masks.py
+++ b/fstd2nc/mixins/masks.py
@@ -65,9 +65,6 @@ class Masks (BufferBase):
     if mask_key is not None:
       mask = self._fstluk(mask_key, rank=rank)['d']
       prm['d'] *= mask
-#      prm['d'] += self._fill_value * (1-mask)
-# To avoid getting  
-# TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('uint32') with casting rule 'same_kind'
-      prm['d'] = prm['d'] + self._fill_value * (1-mask)
+      prm['d'] += self._fill_value * (1-mask)
     return prm
 

--- a/fstd2nc/mixins/netcdf.py
+++ b/fstd2nc/mixins/netcdf.py
@@ -323,8 +323,8 @@ class netCDF_IO (BufferBase):
     bar = Bar(_("Saving netCDF file"), suffix="%(percent)d%% [%(myeta)s]")
     for r,shape,v,ind in bar.iter(sorted(io)):
       try:
-        data = self._fstluk(r)['d'].transpose().reshape(shape)
-        v[ind] = data.view(v.dtype)
+        data = self._fstluk(r,dtype=v.dtype)['d'].transpose().reshape(shape)
+        v[ind] = data
       except (IndexError,ValueError):
         warn(_("Internal problem with the script - unable to get data for '%s'")%v.name)
         continue


### PR DESCRIPTION
Do the type casting immediately, so the mask operates on the expected values.