### PR TITLE
Keep 'nomvar' as attribute if 'rename' is defined in metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ optional arguments:
   -h, --help            show this help message and exit
   --version             show program's version number and exit
   --no-progress         Disable the progress bar.
-  --minimal-metadata [nomvar,...]
+  --minimal-metadata    Don't include RPN record attributes and other internal
+                        information in the output metadata.
+  --rpnstd-metadata-list nomvar,...
                         Specify a minimal set of RPN record attributes to
-                        include in the output file. If you use this flag
-                        without any values, then no RPN attributes will be
-                        included.
+                        include in the output file.
   --ignore-typvar       Tells the converter to ignore the typvar when deciding
                         if two records are part of the same field. Default is
                         to split the variable on different typvars.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ optional arguments:
   -h, --help            show this help message and exit
   --version             show program's version number and exit
   --no-progress         Disable the progress bar.
-  --minimal-metadata    Don't include RPN record attributes and other internal
-                        information in the output metadata.
+  --minimal-metadata [nomvar,...]
+                        Specify a minimal set of RPN record attributes to
+                        include in the output file. If you use this flag
+                        without any values, then no RPN attributes will be
+                        included.
   --ignore-typvar       Tells the converter to ignore the typvar when deciding
                         if two records are part of the same field. Default is
                         to split the variable on different typvars.

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -214,7 +214,7 @@ class BufferBase (object):
     _('Display a progress bar during the conversion, if the "progress" module is installed.')
     group.add_argument('--progress', action='store_true', default=True, help=SUPPRESS)
     group.add_argument('--no-progress', action='store_false', dest='progress', help=_('Disable the progress bar.'))
-    parser.add_argument('--minimal-metadata', action='store_true', help=_("Don't include RPN record attributes and other internal information in the output metadata."))
+    parser.add_argument('--minimal-metadata', nargs='?', metavar='nomvar,...', default=False, const='', help=_("Specify a minimal set of RPN record attributes to include in the output file.  If you use this flag without any values, then no RPN attributes will be included."))
     parser.add_argument('--ignore-typvar', action='store_true', help=_('Tells the converter to ignore the typvar when deciding if two records are part of the same field.  Default is to split the variable on different typvars.'))
     parser.add_argument('--ignore-etiket', action='store_true', help=_('Tells the converter to ignore the etiket when deciding if two records are part of the same field.  Default is to split the variable on different etikets.'))
     parser.add_argument('--no-quick-scan', action='store_true', help=SUPPRESS)
@@ -303,7 +303,10 @@ class BufferBase (object):
     # Set up a progress bar for scanning the input files.
     Bar = _ProgressBar if progress is True else _FakeBar
 
+    if minimal_metadata is not False:
+      minimal_metadata = tuple(minimal_metadata.split(','))
     self._minimal_metadata = minimal_metadata
+
     if not ignore_typvar:
       # Insert typvar value just after nomvar.
       self._var_id = self._var_id[0:1] + ('typvar',) + self._var_id[1:]

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -303,8 +303,12 @@ class BufferBase (object):
     # Set up a progress bar for scanning the input files.
     Bar = _ProgressBar if progress is True else _FakeBar
 
-    if minimal_metadata is not False:
-      minimal_metadata = tuple(minimal_metadata.split(','))
+    if minimal_metadata is True:
+      minimal_metadata = ''
+    if isinstance(minimal_metadata,str):
+      minimal_metadata = minimal_metadata.split(',')
+    if hasattr(minimal_metadata,'__len__'):
+      minimal_metadata = tuple(minimal_metadata)
     self._minimal_metadata = minimal_metadata
 
     if not ignore_typvar:

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -214,7 +214,9 @@ class BufferBase (object):
     _('Display a progress bar during the conversion, if the "progress" module is installed.')
     group.add_argument('--progress', action='store_true', default=True, help=SUPPRESS)
     group.add_argument('--no-progress', action='store_false', dest='progress', help=_('Disable the progress bar.'))
-    parser.add_argument('--minimal-metadata', nargs='?', metavar='nomvar,...', default=False, const='', help=_("Specify a minimal set of RPN record attributes to include in the output file.  If you use this flag without any values, then no RPN attributes will be included."))
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--minimal-metadata', action='store_true', help=_("Don't include RPN record attributes and other internal information in the output metadata."))
+    group.add_argument('--rpnstd-metadata-list', metavar='nomvar,...', help=_("Specify a minimal set of RPN record attributes to include in the output file."))
     parser.add_argument('--ignore-typvar', action='store_true', help=_('Tells the converter to ignore the typvar when deciding if two records are part of the same field.  Default is to split the variable on different typvars.'))
     parser.add_argument('--ignore-etiket', action='store_true', help=_('Tells the converter to ignore the etiket when deciding if two records are part of the same field.  Default is to split the variable on different etikets.'))
     parser.add_argument('--no-quick-scan', action='store_true', help=SUPPRESS)
@@ -279,7 +281,7 @@ class BufferBase (object):
   ###############################################
   # Basic flow for reading data
 
-  def __init__ (self, filename, progress=False, minimal_metadata=False, ignore_typvar=False, ignore_etiket=False, no_quick_scan=False):
+  def __init__ (self, filename, progress=False, minimal_metadata=False, rpnstd_metadata_list=None, ignore_typvar=False, ignore_etiket=False, no_quick_scan=False):
     """
     Read raw records from FSTD files, into the buffer.
     Multiple files can be read simultaneously.
@@ -304,12 +306,12 @@ class BufferBase (object):
     Bar = _ProgressBar if progress is True else _FakeBar
 
     if minimal_metadata is True:
-      minimal_metadata = ''
-    if isinstance(minimal_metadata,str):
-      minimal_metadata = minimal_metadata.split(',')
-    if hasattr(minimal_metadata,'__len__'):
-      minimal_metadata = tuple(minimal_metadata)
-    self._minimal_metadata = minimal_metadata
+      rpnstd_metadata_list = ''
+    if isinstance(rpnstd_metadata_list,str):
+      rpnstd_metadata_list = rpnstd_metadata_list.split(',')
+    if hasattr(rpnstd_metadata_list,'__len__'):
+      rpnstd_metadata_list = tuple(rpnstd_metadata_list)
+    self._rpnstd_metadata_list = rpnstd_metadata_list
 
     if not ignore_typvar:
       # Insert typvar value just after nomvar.

--- a/fstd2nc/mixins/netcdf.py
+++ b/fstd2nc/mixins/netcdf.py
@@ -68,7 +68,7 @@ class netCDF_Atts (BufferBase):
         var.atts.update(self._metadata[var.name])
         # Rename the field? (Using special 'rename' key in the metadata file).
         if 'rename' in var.atts:
-          var.name = var.atts['rename']
+          var.name = var.atts.pop('rename')
           # Also rename any axis with this name.
           axis_renames[orig_name] = var.name
 
@@ -241,16 +241,10 @@ class netCDF_IO (BufferBase):
         var.name = '_'+var.name
 
       # Strip out FSTD-specific metadata?
-      if self._minimal_metadata:
-        var_internal_meta = internal_meta
-        # Keep 'nomvar' as attribute if 'rename' is defined in metadata file
-        if 'rename' in var.atts and 'nomvar' in internal_meta:
-          var.atts.pop('rename')
-          metalist = list(internal_meta)
-          metalist.remove('nomvar')
-          var_internal_meta = tuple(metalist)
-        for n in var_internal_meta:
-          var.atts.pop(n,None)
+      if self._minimal_metadata is not False:
+        for n in internal_meta:
+          if n not in self._minimal_metadata:
+            var.atts.pop(n,None)
 
 
   def write_nc_file (self, filename, nc_format='NETCDF4', global_metadata=None, zlib=False, progress=False):

--- a/fstd2nc/mixins/netcdf.py
+++ b/fstd2nc/mixins/netcdf.py
@@ -241,9 +241,9 @@ class netCDF_IO (BufferBase):
         var.name = '_'+var.name
 
       # Strip out FSTD-specific metadata?
-      if self._minimal_metadata is not False:
+      if self._rpnstd_metadata_list is not None:
         for n in internal_meta:
-          if n not in self._minimal_metadata:
+          if n not in self._rpnstd_metadata_list:
             var.atts.pop(n,None)
 
 

--- a/fstd2nc/mixins/netcdf.py
+++ b/fstd2nc/mixins/netcdf.py
@@ -68,7 +68,7 @@ class netCDF_Atts (BufferBase):
         var.atts.update(self._metadata[var.name])
         # Rename the field? (Using special 'rename' key in the metadata file).
         if 'rename' in var.atts:
-          var.name = var.atts.pop('rename')
+          var.name = var.atts['rename']
           # Also rename any axis with this name.
           axis_renames[orig_name] = var.name
 
@@ -242,7 +242,14 @@ class netCDF_IO (BufferBase):
 
       # Strip out FSTD-specific metadata?
       if self._minimal_metadata:
-        for n in internal_meta:
+        var_internal_meta = internal_meta
+        # Keep 'nomvar' as attribute if 'rename' is defined in metadata file
+        if 'rename' in var.atts and 'nomvar' in internal_meta:
+          var.atts.pop('rename')
+          metalist = list(internal_meta)
+          metalist.remove('nomvar')
+          var_internal_meta = tuple(metalist)
+        for n in var_internal_meta:
           var.atts.pop(n,None)
 
 

--- a/fstd2nc/mixins/vcoords.py
+++ b/fstd2nc/mixins/vcoords.py
@@ -196,8 +196,9 @@ class VCoords (BufferBase):
                 except (KeyError,VGDError):
                   pass  # Some keys not available in some vgrids?
               # Put this information in the final output file?
-              if not self._minimal_metadata:
-                atts.update(internal_atts)
+              for k,v in internal_atts.items():
+                if self._minimal_metadata is False or k in self._minimal_metadata:
+                  atts[k] = v
               # Attempt to fill in A/B ancillary data (if available).
               try:
                 all_z = list(internal_atts['VCDM'])+list(internal_atts['VCDT'])

--- a/fstd2nc/mixins/vcoords.py
+++ b/fstd2nc/mixins/vcoords.py
@@ -197,7 +197,7 @@ class VCoords (BufferBase):
                   pass  # Some keys not available in some vgrids?
               # Put this information in the final output file?
               for k,v in internal_atts.items():
-                if self._minimal_metadata is False or k in self._minimal_metadata:
+                if self._rpnstd_metadata_list is None or k in self._rpnstd_metadata_list:
                   atts[k] = v
               # Attempt to fill in A/B ancillary data (if available).
               try:


### PR DESCRIPTION
I'm proposing that we keep nomvar as an attribute when the variable is renamed, so that we can still keep track of its origin. What do you think?