### PR TITLE
Option to remove some dimensions / variables from the output file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ optional arguments:
   --filter CONDITION    Subset RPN file records using the given criteria. For
                         example, to convert only 24-hour forecasts you could
                         use --filter ip2==24
-  --exclude NAME1,NAME2,...
+  --exclude NAME,NAME,...
                         Exclude some axes or derived variables from the
-                        output. Note that axes can only be excluded if they
+                        output. Note that axes will only be excluded if they
                         have a length of 1.
   --metadata-file METADATA_FILE
                         Use metadata from the specified file. You can repeat

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ optional arguments:
   --filter CONDITION    Subset RPN file records using the given criteria. For
                         example, to convert only 24-hour forecasts you could
                         use --filter ip2==24
+  --omit NAME1,NAME2,...
+                        Omit some axes or derived variables from the output.
+                        Note that axes can only be omitted if they have a
+                        length of 1.
   --metadata-file METADATA_FILE
                         Use metadata from the specified file. You can repeat
                         this option multiple times to build metadata from

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ optional arguments:
   --filter CONDITION    Subset RPN file records using the given criteria. For
                         example, to convert only 24-hour forecasts you could
                         use --filter ip2==24
-  --omit NAME1,NAME2,...
-                        Omit some axes or derived variables from the output.
-                        Note that axes can only be omitted if they have a
-                        length of 1.
+  --exclude NAME1,NAME2,...
+                        Exclude some axes or derived variables from the
+                        output. Note that axes can only be excluded if they
+                        have a length of 1.
   --metadata-file METADATA_FILE
                         Use metadata from the specified file. You can repeat
                         this option multiple times to build metadata from

--- a/fstd2nc/__init__.py
+++ b/fstd2nc/__init__.py
@@ -46,12 +46,13 @@ from fstd2nc.mixins.vcoords import VCoords
 from fstd2nc.mixins.xycoords import XYCoords
 from fstd2nc.mixins.misc import NoNK
 from fstd2nc.mixins.filter import FilterRecords
+from fstd2nc.mixins.removestuff import RemoveStuff
 from fstd2nc.mixins.pruneaxes import PruneAxes
 from fstd2nc.mixins.netcdf import netCDF_Atts, netCDF_IO
 from fstd2nc.mixins.array import XArray
 from fstd2nc.mixins.iter import Iter
 
-class Buffer (Iter,XArray,netCDF_IO,netCDF_Atts,PruneAxes,FilterRecords,NoNK,XYCoords,VCoords,Sfc_Codes,Series,Dates,Masks,SelectVars):
+class Buffer (Iter,XArray,netCDF_IO,netCDF_Atts,PruneAxes,RemoveStuff,FilterRecords,NoNK,XYCoords,VCoords,Sfc_Codes,Series,Dates,Masks,SelectVars):
   """
   High-level interface for FSTD data, to treat it as multi-dimensional arrays.
   Contains logic for dealing with most of the common FSTD file conventions.

--- a/fstd2nc/mixins/netcdf.py
+++ b/fstd2nc/mixins/netcdf.py
@@ -180,7 +180,11 @@ class netCDF_IO (BufferBase):
     for attname, attval in list(atts.items()):
       # Detect list of objects, convert to space-separated string.
       if isinstance(attval,list):
-        atts[attname] = ' '.join(v.name for v in attval)
+        if len(attval) > 0:
+          atts[attname] = ' '.join(v.name for v in attval)
+        # Remove the attribute if the list of objects is empty
+        else:
+          atts.pop(attname)
     return atts
 
   def _fix_names (self, varlist):

--- a/fstd2nc/mixins/removestuff.py
+++ b/fstd2nc/mixins/removestuff.py
@@ -30,7 +30,7 @@ class RemoveStuff (BufferBase):
   @classmethod
   def _cmdline_args (cls, parser):
     super(RemoveStuff,cls)._cmdline_args(parser)
-    parser.add_argument('--exclude', metavar='NAME1,NAME2,...', help=_("Exclude some axes or derived variables from the output.  Note that axes can only be excluded if they have a length of 1."))
+    parser.add_argument('--exclude', metavar='NAME,NAME,...', help=_("Exclude some axes or derived variables from the output.  Note that axes will only be excluded if they have a length of 1."))
 
   def __init__ (self, *args, **kwargs):
     import numpy as np
@@ -45,8 +45,15 @@ class RemoveStuff (BufferBase):
   def _iter (self):
     from fstd2nc.mixins import _var_type, _iter_type
     for var in super(RemoveStuff,self)._iter():
+
+      # Omit the excluded variables from the data stream.
+      # Note: will not remove the var associated with an axis if the axis is
+      # non-degenerate.
       if var.name in self._exclude:
-        continue
+        if list(var.axes.keys()) != [var.name]:
+          continue
+        elif len(var.axes[var.name]) == 1:
+          continue
 
       # Remove the excluded axes.
       for exclude in self._exclude:

--- a/fstd2nc/mixins/removestuff.py
+++ b/fstd2nc/mixins/removestuff.py
@@ -1,0 +1,80 @@
+###############################################################################
+# Copyright 2017 - Climate Research Division
+#                  Environment and Climate Change Canada
+#
+# This file is part of the "fstd2nc" package.
+#
+# "fstd2nc" is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# "fstd2nc" is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with "fstd2nc".  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+from fstd2nc.stdout import _, info, warn, error
+from fstd2nc.mixins import BufferBase
+
+
+#################################################
+# Mixin for removing variables and degenerate axes from the stream.
+
+class RemoveStuff (BufferBase):
+
+  @classmethod
+  def _cmdline_args (cls, parser):
+    super(RemoveStuff,cls)._cmdline_args(parser)
+    parser.add_argument('--omit', metavar='NAME1,NAME2,...', help=_("Omit some axes or derived variables from the output.  Note that axes can only be omitted if they have a length of 1."))
+
+  def __init__ (self, *args, **kwargs):
+    import numpy as np
+    omit = kwargs.pop('omit',None)
+    if omit is None:
+      omit = []
+    if isinstance(omit,str):
+      omit = omit.split(',')
+    self._omit = tuple(omit)
+    super(RemoveStuff,self).__init__(*args,**kwargs)
+
+  def _iter (self):
+    from fstd2nc.mixins import _var_type, _iter_type
+    for var in super(RemoveStuff,self)._iter():
+      if var.name in self._omit:
+        continue
+
+      # Remove omitted axes.
+      for omit in self._omit:
+        axisnames = list(var.axes.keys())
+        if omit in axisnames and len(var.axes[omit]) == 1:
+          i = axisnames.index(omit)
+          var.axes.pop(omit)
+          if isinstance(var,_var_type):
+            shape = var.array.shape
+            shape = shape[:i] + shape[i+1:]
+            var.array = var.array.reshape(shape)
+          if isinstance(var,_iter_type):
+            shape = var.record_id.shape
+            shape = shape[:i] + shape[i+1:]
+            var.record_id = var.record_id.reshape(shape)
+
+      # Remove all references to omitted vars from the metadata.
+      for key,val in list(var.atts.items()):
+        if isinstance(val,str):
+          val = val.split()
+          for omit in self._omit:
+            if omit in val:
+              val[val.index(omit)] = None
+          val = filter(None,val)
+          var.atts[key] = ' '.join(val)
+        # Special case - list of object references
+        elif isinstance(val,list):
+          val = [v for v in val if v.name not in self._omit]
+          var.atts[key] = val
+
+      yield var

--- a/fstd2nc/mixins/removestuff.py
+++ b/fstd2nc/mixins/removestuff.py
@@ -72,15 +72,8 @@ class RemoveStuff (BufferBase):
 
       # Remove all references to excluded vars from the metadata.
       for key,val in list(var.atts.items()):
-        if isinstance(val,str):
-          val = val.split()
-          for exclude in self._exclude:
-            if exclude in val:
-              val[val.index(exclude)] = None
-          val = filter(None,val)
-          var.atts[key] = ' '.join(val)
         # Special case - list of object references
-        elif isinstance(val,list):
+        if isinstance(val,list):
           val = [v for v in val if v.name not in self._exclude]
           var.atts[key] = val
 


### PR DESCRIPTION
This introduces a new option (currently called `--exclude`), which allows the user to remove certain things they don't want in the final output file.
### Examples
`--exclude time` could be used on an FSTD file which is time invariant (such as "geophysical" files) to remove the irrelevant time axis. 
`--exclude height` would remove a degenerate (0m) height dimension from the output file.
`--exclude leadtime,reftime` would remove the forecast period and reference time information from the output file.