### PR TITLE
Support for time-dependent lat/lon

### DIFF
--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -358,7 +358,13 @@ class XYCoords (BufferBase):
     # Only output 1 copy of 1D coords (e.g. could have repetitions with
     # horizontal staggering.
     coords = set()
-    for var in super(XYCoords,self)._iter():
+
+    # Make sure any LA/LO records get processed first, so we can apply them as
+    # coordinates to other variables.
+    varlist = list(super(XYCoords,self)._iter())
+    varlist = [v for v in varlist if v.name in ('LA','LO')] + [v for v in varlist if v.name not in ('LA','LO')]
+
+    for var in varlist:
       # Don't touch derived variables.
       if not isinstance(var,_iter_type):
         yield var

--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -422,6 +422,7 @@ class XYCoords (BufferBase):
             if grtyp in self._direct_grids:
               latarray = self._find_coord(var,'^^')['d'].squeeze(axis=2)
               lonarray = self._find_coord(var,'>>')['d'].squeeze(axis=2)
+            # Handle ezqkdef grids.
             else:
               gdid = ezqkdef (ni, nj, grtyp, ig1, ig2, ig3, ig4, self._meta_funit)
               ll = gdll(gdid)
@@ -439,12 +440,29 @@ class XYCoords (BufferBase):
           except (TypeError,EzscintError,KeyError,RMNError,ValueError):
             pass
 
+          # Check for LA/LO variables, and use these as the coordinates if
+          # nothing else available.
+          if latarray is None and var.name == 'LA':
+            var.name = 'lat'
+            var.atts.update(latatts)
+            yield var
+            #grids[key] = list(var.axes.items())
+            lats[key] = var
+            continue
+          if lonarray is None and var.name == 'LO':
+            var.name = 'lon'
+            var.atts.update(lonatts)
+            yield var
+            grids[key] = list(var.axes.items())
+            lons[key] = var
+            continue
+
           if latarray is None or lonarray is None:
             warn(_("Unable to get lat/lon coordinates for '%s'")%var.name)
             yield var
             continue
 
-          # Construct lat/lon variables.
+          # Construct lat/lon variables from latarray and lonarray.
           latarray = latarray.transpose() # Switch from Fortran to C order.
           lonarray = lonarray.transpose() # Switch from Fortran to C order.
 
@@ -557,6 +575,12 @@ class XYCoords (BufferBase):
 
       if key in gridmaps:
         var.atts['grid_mapping'] = gridmaps[key]
+
+      # Throw out superfluous LA/LO variables, if lat/lon was already decoded.
+      if var.name == 'LA' and ('lat' in var.axes or 'lat' in coordinates):
+        continue
+      if var.name == 'LO' and ('lon' in var.axes or 'lon' in coordinates):
+        continue
 
       yield var
 


### PR DESCRIPTION
Some logic for interpreting LA/LO variables as time-dependent lat/lon coordinates.
Pretty much a rebase of #13, but without requiring a complete re-ordering of the variables.  This should make it easier to validate using nccmp.
