### PR TITLE
Refactor xarray+dask interface to support multi-threading

### DIFF
--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -25,6 +25,117 @@ approaches (not the standard librmn/rpnpy functions).
 This is solely for performance considerations.
 """
 
+from rpnpy.librmn import librmn
+import ctypes as ct
+import numpy as np
+import numpy.ctypeslib as npc
+librmn.compact_float.argtypes = (npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.POINTER(ct.c_double))
+librmn.compact_double.argtypes = (npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.POINTER(ct.c_double))
+librmn.compact_integer.argtypes = (npc.ndpointer(dtype='int32'), ct.c_void_p, npc.ndpointer(dtype='int32'), ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int)
+librmn.ieeepak_.argtypes = (npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), ct.POINTER(ct.c_int), ct.POINTER(ct.c_int), ct.POINTER(ct.c_int), ct.POINTER(ct.c_int), ct.POINTER(ct.c_int))
+librmn.compact_char.argtypes = (npc.ndpointer(dtype='int32'), ct.c_void_p, npc.ndpointer(dtype='int32'), ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int)
+librmn.c_armn_uncompress32.argtypes = (npc.ndpointer(dtype='int32'), npc.ndpointer(dtype='int32'), ct.c_int, ct.c_int, ct.c_int, ct.c_int)
+librmn.c_armn_compress_setswap.argtypes = (ct.c_int,)
+librmn.armn_compress.argtypes = (npc.ndpointer(dtype='int32'),ct.c_int,ct.c_int,ct.c_int,ct.c_int,ct.c_int)
+librmn.c_float_unpacker.argtypes = (npc.ndpointer(dtype='int32'),npc.ndpointer(dtype='int32'),npc.ndpointer(dtype='int32'),ct.c_int,ct.POINTER(ct.c_int))
+
+def decode (data):
+  '''
+  Decodes the raw FSTD data into the final 2D array of values.
+  Similar to fstluk, but here the data is already loaded in memory.
+  The data should also include the 96 bytes of header information at the
+  beginning of the array.
+
+  Parameters
+  ----------
+  data : array
+      The encoded data
+  '''
+  import rpnpy.librmn.all as rmn
+  import numpy as np
+  data = data.view('>i4').astype('i4')
+  ni, nj, nk = data[3]>>8, data[4]>>8, data[5]>>12
+  nelm = ni*nj*nk
+  datyp = data[4]%256 
+  nbits = data[2]%256
+  if nbits <= 32:
+    dtype = rmn.FST_DATYP2NUMPY_LIST[datyp%128]
+    if datyp == 0: dtype = 'float32'
+    work = np.zeros(nelm,'int32')
+  else:
+    dtype = rmn.FST_DATYP2NUMPY_LIST64[datyp%128]
+    if datyp == 0: dtype = 'float64'
+    work = np.zeros(nelm,'int64')
+  work[:] = 999
+  # Strip header
+  data = data[20:]
+  out = np.empty((nj,ni),dtype=dtype)
+  out[()] = 888
+  ni = ct.c_int(ni)
+  nj = ct.c_int(nj)
+  nk = ct.c_int(nk)
+  nelm = ct.c_int(nelm)
+  npak = ct.c_int(-nbits)
+  nbits = ct.c_int(nbits)
+  zero = ct.c_int(0)
+  one = ct.c_int(1)
+  two = ct.c_int(2)
+  tempfloat = ct.c_double(99999.0)
+
+  print (ni, nj, nk, nbits, datyp, dtype)
+  if datyp == 0:
+    out[()] = data.view(out.dtype)[:nelm.value].reshape(out.shape)
+  if datyp == 1:
+    if nbits.value <= 32:
+      librmn.compact_float(work.view('int32'), data, data[3:], nelm, nbits, 24, 1, 2, 0, ct.byref(tempfloat))
+    else:
+      raise Exception
+      librmn.compact_double(work.view('int32'), data, data[3:], nelm, nbits, 24, 1, 2, 0, ct.byref(tempfloat))
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 2:
+    librmn.compact_integer(work.view('int32'), None, data, nelm, nbits, 0, 1, 2)
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 3:
+    raise Exception
+  if datyp == 4:
+    librmn.compact_integer(work.view('int32'), None, data, nelm, nbits, 0, 1, 4)
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 5:
+    librmn.ieeepak_(work.view('int32'), data, ct.byref(nelm), ct.byref(one), ct.byref(npak), ct.byref(zero), ct.byref(two))
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 6:
+    librmn.c_float_unpacker(work.view('int32'), data, data[3:], nelm, ct.byref(nbits));
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 7:
+    ier = librmn.compact_char(work.view('int32'), None, data, nelm, 8, 0, 1, 10)
+    work = work.view('B')[:len(work)] & 127
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 8:
+    raise Exception
+  if datyp == 129:
+    d = np.zeros(nelm.value + 1000,dtype='int32')
+    d[:len(data)] = data
+    librmn.armn_compress(d[5:],ni,nj,nk,nbits,2)
+    librmn.compact_float(work.view('int32'),d[1:],d[5:],nelm,nbits.value+64*max(16,nbits.value),0,1,2,0,ct.byref(tempfloat))
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 130:
+    d = np.zeros(nelm.value + 1000,dtype='int32')
+    d[:len(data)] = data
+    #librmn.c_armn_compress_setswap(0)
+    librmn.armn_compress(d[1:],ni,nj,nk,nbits,2)
+    #librmn.c_armn_compress_setswap(1)
+    work[:] = d[1:].astype('>i4').view('>H')[:nelm.value]
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 133:
+    librmn.c_armn_uncompress32(work.view('int32'), data[1:], ni, nj, nk, nbits)
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  if datyp == 134:
+    d = np.zeros(nelm.value + 1000,dtype='int32')
+    d[:len(data)] = data
+    librmn.armn_compress(d[4:],ni,nj,nk,nbits,2);
+    librmn.c_float_unpacker(work.view('int32'),d[1:],d[4:],nelm,ct.byref(nbits))
+    out[()] = work.view(out.dtype).reshape(out.shape)
+  return out
 
 def nrecs (f):
   '''

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -134,6 +134,14 @@ def nrecs (f):
   f : file object
       The Python file object to scan for headers.
   '''
+  # Note: having trouble using number of rewrites / erasures to get the
+  # true number of records.  The way librmn computes the total number of
+  # records is to count them over all the directory pages, so we can get that
+  # same count from "all_params".
+  #TODO: more efficient solution.
+  x = all_params (f)
+  return len(x['swa'])
+  # This code ended up not working in some cases, so no longer used.
   import numpy as np
   f.seek(0x14, 0)
   rewrites = np.fromfile(f, '>i4', 1)[0]

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -122,7 +122,7 @@ def decode (data):
   if datyp == 134:
     librmn.armn_compress(data[4:],ni,nj,nk,nbits,2);
     librmn.c_float_unpacker(work,data[1:],data[4:],nelm,ct.byref(nbits))
-  return work.view(dtype)[:nelm.value].reshape(shape)
+  return work.view(dtype)[:nelm.value].reshape(shape).T
 
 def nrecs (f):
   '''
@@ -271,6 +271,22 @@ def all_params (f, out=None):
   out['key'][:] = ((np.array(recno_list)&0x1FF)<<10) | ((np.array(pageno_list)&0xFFF)<<19)
 
   return out
+
+
+# Get the block size for the filesystem where the given file resides.
+# May be useful for determining the best way to read chunks of data from
+# FSTD files.
+def blocksize (filename):
+  import subprocess
+  try:
+    # Use the command-line "stat" program instead of os.stat, because the
+    # latter is giving incorrect results for some filesystems.
+    # E.g., on a GPFS filesystem with 16MB block size, os.stat is giving a size
+    # of 256KB.
+    return int(subprocess.check_output(['stat', '-c', '%s', '-f', filename]))
+  except OSError:
+    return 4096  # Give some default value if 'stat' not available.
+
 
 # Lightweight test for FST files.
 # Uses the same test for fstd98 random files from wkoffit.c (librmn 16.2).

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -43,7 +43,7 @@ def decode (data):
   '''
   Decodes the raw FSTD data into the final 2D array of values.
   Similar to fstluk, but here the data is already loaded in memory.
-  The data should also include the 96 bytes of header information at the
+  The data should also include the header information at the
   beginning of the array.
 
   Parameters

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -135,8 +135,11 @@ def nrecs (f):
       The Python file object to scan for headers.
   '''
   import numpy as np
+  f.seek(0x14, 0)
+  rewrites = np.fromfile(f, '>i4', 1)[0]
   f.seek(0x34, 0)
-  return int(np.fromfile(f, '>i4', 1)[0].astype('uint32'))
+  valid_records = np.fromfile(f, '>i4', 1)[0]
+  return int(valid_records + rewrites)
 
 
 def all_params (f, out=None):

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -988,7 +988,7 @@ class BufferBase (object):
 
   # How to decode the data from a raw binary array.
   def _decode (self, data):
-    from fstd2nc.extra import decode_headers, decode
+    from fstd2nc.extra import decode
     nbits = int(data[0x0b])
     datyp = int(data[0x13])
     dtype = dtype_fst2numpy(datyp, nbits)

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -986,6 +986,12 @@ class BufferBase (object):
 
       return fstluk (key, dtype, rank, dataArray)
 
+  # How to decode the data from a raw binary array.
+  def _decode (self, data):
+    from fstd2nc.extra import decode
+    return decode(data)
+
+
   #
   ###############################################
 

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -988,9 +988,12 @@ class BufferBase (object):
 
   # How to decode the data from a raw binary array.
   def _decode (self, data):
-    from fstd2nc.extra import decode
-    return decode(data)
-
+    from fstd2nc.extra import decode_headers, decode
+    nbits = int(data[0x0b])
+    datyp = int(data[0x13])
+    dtype = dtype_fst2numpy(datyp, nbits)
+    out = decode(data).view(dtype)
+    return out
 
   #
   ###############################################

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -186,7 +186,7 @@ class ExternOutput (BufferBase):
                 graph = graphs[rec_id][None]
                 dsk.update(graphs[rec_id])
                 del dsk[None]
-                dsk[key] = (np.ndarray.view, (np.reshape, graph, chunk_shape), var.dtype)
+                dsk[key] = (np.reshape, graph, chunk_shape)
           else:
             # Fill missing chunks with fill value or NaN.
             if hasattr(self,'_fill_value'):

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -186,7 +186,7 @@ class ExternOutput (BufferBase):
                 graph = graphs[rec_id][None]
                 dsk.update(graphs[rec_id])
                 del dsk[None]
-                dsk[key] = (np.reshape, graph, chunk_shape)
+                dsk[key] = (np.ndarray.view, (np.reshape, graph, chunk_shape), var.dtype)
           else:
             # Fill missing chunks with fill value or NaN.
             if hasattr(self,'_fill_value'):

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -28,7 +28,6 @@ import collections
 # Method for reading a block from a file.
 def _read_block (filename, offset, length):
   import numpy as np
-  print ("READ OFFSET %X"%offset)
   with open(filename,'rb') as f:
     f.seek (offset,0)
     return np.fromfile(f,'B',length)
@@ -41,26 +40,6 @@ def _subset (block, start, end):
 def _concat (*data):
   import numpy as np
   return np.concatenate(data)
-
-# Open a file for raw binary access using dask.
-def _open_binary (filename):
-  from fstd2nc.extra import blocksize
-  from os.path import getsize
-  from dask import array as da
-  # Get a good chunk size for splitting the binary file into dask chunks.
-  # Use the filesystem block size unless it's too small.
-  chunksize = max(blocksize(filename), 2**20)
-  filesize = getsize(filename)
-  dsk = dict()
-  chunks = []
-  for n, offset in enumerate(range(0,filesize,chunksize)):
-    end = min(offset+chunksize,filesize)
-    length = end - offset
-    chunks.append(length)
-    key = (filename,n)
-    dsk[key] = (_read_block, filename, offset, length)
-  array = da.Array(dsk, filename, [chunks], 'B')
-  return array
 
 
 class ExternOutput (BufferBase):

--- a/fstd2nc/mixins/interp.py
+++ b/fstd2nc/mixins/interp.py
@@ -114,3 +114,34 @@ class Interp (BufferBase):
     prm['d'] = d
     return prm
 
+  # Handle grid interpolations from raw binary array.
+  def _decode (self, data, _grid_cache={}):
+    import rpnpy.librmn.all as rmn
+    import numpy as np
+    from fstd2nc.extra import decode_headers, decode
+    if not hasattr(self,'_interp_grid'):
+      return super(Interp,self)._decode (data)
+    grid_params = ('ni','nj','grtyp','ig1','ig2','ig3','ig4')
+    prm = decode_headers(data[:72])
+    prm = dict((k,v[0]) for k,v in prm.items())
+    prm['d'] = super(Interp,self)._decode (data)
+    with self._lock:
+      cache_key = tuple(prm[k] for k in grid_params)
+      # Check if we've already defined the input grid in a previous call.
+      if cache_key in _grid_cache:
+        ingrid = _grid_cache[cache_key]
+      else:
+        ingrid = dict((k,(str(prm[k].decode()) if k=='grtyp' else int(prm[k]))) for k in grid_params)
+        ingrid['iunit'] = self._meta_funit
+        ingrid = rmn.ezqkdef (**ingrid)
+        _grid_cache[cache_key] = ingrid
+
+    # Propogate any fill values to the interpolated grid.
+    in_mask = np.zeros(prm['d'].shape, order='F', dtype='float32')
+    in_mask[prm['d']==self._fill_value] = 1.0
+    d = rmn.ezsint (self._interp_grid, ingrid, prm['d'])
+    out_mask = rmn.ezsint (self._interp_grid, ingrid, in_mask)
+    d[out_mask!=0] = self._fill_value
+    # Return the data for the interpolated field.
+    return d
+

--- a/fstd2nc/mixins/interp.py
+++ b/fstd2nc/mixins/interp.py
@@ -85,6 +85,18 @@ class Interp (BufferBase):
     else:
       super(Interp,self).__init__(*args,**kwargs)
 
+  # Add fill value to the data.
+  # Modified from code in from mask mixin.
+  # Set this fill value for any interpolated data, since it may contain
+  # points outside the original boundary.
+  def _makevars (self):
+    from fstd2nc.mixins import _iter_type
+    super(Interp,self)._makevars()
+    if hasattr(self,'_interp_grid'):
+      for var in self._varlist:
+        if isinstance(var,_iter_type):
+          var.atts['_FillValue'] = var.dtype.type(self._fill_value)
+
   # Handle grid interpolation
   def _fstluk (self, rec_id, dtype=None, rank=None, dataArray=None, _grid_cache={}):
     import rpnpy.librmn.all as rmn

--- a/fstd2nc/mixins/interp.py
+++ b/fstd2nc/mixins/interp.py
@@ -67,6 +67,11 @@ class Interp (BufferBase):
       iun = rmn.fstopenall(gridfile, rmn.FST_RW)
       rmn.writeGrid (iun, self._interp_grid)
       rmn.fstcloseall (iun)
+      # Handle case where a single file was passed from the Python interface.
+      if isinstance(args[0],str):
+        args = list(args)
+        args[0] = [args[0]]
+        args = tuple(args)
       # Add this grid file to the inputs.
       args[0].append(gridfile)
       super(Interp,self).__init__(*args,**kwargs)

--- a/fstd2nc/mixins/masks.py
+++ b/fstd2nc/mixins/masks.py
@@ -74,3 +74,8 @@ class Masks (BufferBase):
       prm['d'] += self._fill_value * (1-mask)
     return prm
 
+  # Apply the mask data from raw binary array.
+  def _decode (self, data):
+    unmasked = super(Masks,self)._decode(data)
+    return unmasked
+    #raise Exception #TODO

--- a/fstd2nc/mixins/masks.py
+++ b/fstd2nc/mixins/masks.py
@@ -115,9 +115,9 @@ class Masks (BufferBase):
     field2 = super(Masks,self)._decode(data)
     # Apply the mask.
     if code1 == 2080:
-      return (field1*field2) + self._fill_value * (1-field1)
+      return ((field1*field2) + self._fill_value * (1-field1)).astype(field2.dtypee)
     elif code2 == 2080:
-      return (field1*field2) + self._fill_value * (1-field2)
+      return ((field1*field2) + self._fill_value * (1-field2)).astype(field1.dtype)
     else:
       # Don't know how to apply this typvar for masking purposes.
       return field1


### PR DESCRIPTION
These updates add a new low-level routine for xarray/dask to circumvent `fstluk` and call the decompressing / decoding routines directly on an in-memory buffer.  This avoids some threading issues with fstluk, such as:
* fstluk allocates a lot of memory on the stack instead of the heap, and stack memory for Python threads is very limited by default.  See #24.
* fstluk changes the global state (position of file pointer, flag for indicating single/double precision, etc.).

Because of these issues there were thread locks around much of the code, effectively making dask run in serial.

To avoid these problems, the new approach is:
1) Read raw binary data directly from file using Python / numpy routines.  The file can be quickly opened / read independently in each thread without any calls to librmn.  Literally just reads bytes `(swa-1)*8` to `(swa-1+lng)*8` into a byte array.
2) Determine the type of data, and call the appropriate low-level librmn decoding routine using ctypes.  The helper function for doing this is `fstd2nc.extra.decode()`. The low-level librmn routines are stateless, so should be thread-safe.

The dask interface is also modified to read the raw data one filesystem "block" at a time but then no particular order of decoding the data within the block.  The old approach was to force dask to read all records in the order they're found on disk, which may be too restrictive (and slow to initialize the graph, and complicated to implement...).

These changes don't affect the command-line netCDF conversion, which still uses fstluk in a single thread.  These changes only affect the to_xarray() interface.

Tests so far give positive results (getting speedups of ~8x for direct writing to netCDF via xarray).  This also allows more utilization of CPUs (saw up to 1300% utilization for some tests, vs. 100% for old approach).  Need to do some more tests before merging, though, to ensure nothing was broken during the refactor.  These changes also add some dependencies on internal workings of librmn, so need to weigh the benefits against future compatibility issues if/when the library changes.
