### PR TITLE
Add multiprocessing support to file scanner

### DIFF
--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -239,7 +239,12 @@ def decode_headers (raw, out=None):
   out['xtra1'][:] = out['datev']
   out['xtra2'][:] = 0
   out['xtra3'][:] = 0
-
+  # Calculate the handles (keys)
+  # Based loosely on "MAKE_RND_HANDLE" macro in qstdir.h.
+  indices = np.arange(len(out['nomvar']), dtype='int32')
+  recno = indices % 256
+  pageno = indices // 256
+  out['key'][:] = ((recno&0x1FF)<<10) | ((pageno&0xFFF)<<19)
   return out
 
 
@@ -276,9 +281,6 @@ def all_params (f, out=None, decode=True):
   raw = np.concatenate(raw)
   if not decode: return raw
   out = decode_headers (raw, out=out)
-  # Calculate the handles (keys)
-  # Based on "MAKE_RND_HANDLE" macro in qstdir.h.
-  out['key'][:] = ((np.array(recno_list)&0x1FF)<<10) | ((np.array(pageno_list)&0xFFF)<<19)
   return out
 
 # Get the block size for the filesystem where the given file resides.

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -324,3 +324,11 @@ def maybeFST(filename):
     if len(buf) < 16: return False
     # Same check as c_wkoffit in librmn
     return buf[12:] == b'STDR'
+
+def get_headers (f):
+  import os
+  if os.path.exists(f) and maybeFST(f):
+    return all_params(open(f,'rb'),decode=False)
+  else:
+    return None
+  return headers

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -252,9 +252,14 @@ def raw_headers (filename):
   '''
   import numpy as np
   import os
-  if not os.path.exists(filename) or not maybeFST(filename):
+  if not os.path.exists(filename):
     return None
   f = open(filename,'rb')
+  # Use same check as maybeFST
+  magic = f.read(16)
+  if len(magic) < 16 or magic[12:] != b'STDR':
+    f.close()
+    return None
   # Get the raw (packed) parameters.
   pageaddr = 27; pageno = 0
   raw = []

--- a/fstd2nc/extra.py
+++ b/fstd2nc/extra.py
@@ -243,7 +243,7 @@ def decode_headers (raw, out=None):
   return out
 
 
-def all_params (f, out=None):
+def all_params (f, out=None, decode=True):
   '''
   Extract record headers from the specified file.
   Returns a dictionary similar to fstprm, only the entries are
@@ -274,6 +274,7 @@ def all_params (f, out=None):
     pageno_list.extend([pageno]*nent)
     pageaddr = page[4]; pageno += 1
   raw = np.concatenate(raw)
+  if not decode: return raw
   out = decode_headers (raw, out=out)
   # Calculate the handles (keys)
   # Based on "MAKE_RND_HANDLE" macro in qstdir.h.

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -426,12 +426,15 @@ class BufferBase (object):
           expanded_infiles.append((infile,f))
 
     # Extract headers from the files.
-    bar = Bar(_("Inspecting input files"), suffix='%(percent)d%% (%(index)d/%(max)d)', max=len(expanded_infiles))
-    with Pool() as p:
-      headers = p.imap (raw_headers, [f for (infile,f) in expanded_infiles])
-      headers = bar.iter(headers)
-      headers = list(headers) # Start!
-    bar.finish()
+    if len(expanded_infiles) > 1:
+      bar = Bar(_("Inspecting input files"), suffix='%(percent)d%% (%(index)d/%(max)d)', max=len(expanded_infiles))
+      with Pool() as p:
+        headers = p.imap (raw_headers, [f for (infile,f) in expanded_infiles])
+        headers = bar.iter(headers)
+        headers = list(headers) # Start!
+      bar.finish()
+    else:
+      headers = list(map(raw_headers, [f for (infile,f) in expanded_infiles]))
 
     # Check which files had headers used, report on the results.
     matches = Counter()

--- a/fstd2nc/mixins/__init__.py
+++ b/fstd2nc/mixins/__init__.py
@@ -369,12 +369,13 @@ class BufferBase (object):
     """
     from rpnpy.librmn.fstd98 import fstnbr, fstinl, fstprm, fstopenall
     from rpnpy.librmn.const import FST_RO
-    from fstd2nc.extra import maybeFST as isFST
-    from collections import Counter
+    from fstd2nc.extra import maybeFST as isFST, all_params, decode_headers
+    from collections import Counter, deque
     import numpy as np
     from glob import glob, has_magic
     import os
     import warnings
+    from threading import Thread
 
     # Set up lock for threading.
     # The same lock is shared for all Buffer objects, to synchronize access to
@@ -424,42 +425,64 @@ class BufferBase (object):
         else:
           expanded_infiles.append((infile,f))
 
-    # Inspect all input files, and extract the headers from valid RPN files.
-    matches = Counter()
-    headers = []
-    self._files = []
+    # Find out which of those files are valid input files.
+    is_valid = [None] * len(expanded_infiles)
+    headers = [None] * len(expanded_infiles)
+    # First, short-circuit the check for cached data.
     if header_cache is None: header_cache = {}
-
-    # Show a progress bar when there are multiple input files.
-    if len(expanded_infiles) > 1:
-      expanded_infiles = Bar(_("Inspecting input files"), suffix='%(percent)d%% (%(index)d/%(max)d)').iter(expanded_infiles)
-
-    for infile, f in expanded_infiles:
+    for i, (infile, f) in enumerate(expanded_infiles):
       fkey = f
       if fkey.startswith('/'):
         fkey = '__ROOT__'+fkey
-      if fkey not in header_cache and (not os.path.exists(f) or not isFST(f)):
+      if fkey in header_cache:
+        is_valid[i] = True
+        headers[i] = header_cache[fkey]
+    # Next, inspect the remaining entries to see which ones are valid.
+    # Extract headers for the valid ones.
+    def check_valid (i):
+      infile, f = expanded_infiles[i]
+      is_valid[i] = os.path.exists(f) and isFST(f)
+      headers[i] = all_params(open(f,'rb'),decode=False)
+    threads = deque()
+    bar = Bar(_("Inspecting input files"), suffix='%(percent)d%% (%(index)d/%(max)d)', max=len(expanded_infiles))
+    for i in range(len(expanded_infiles)):
+      if is_valid[i] is not None: continue
+      while len(threads) >= 32:
+        t = threads.popleft()
+        t.join()
+        bar.next()
+      threads.append(Thread(None, target=check_valid, args=(i,)))
+      threads[-1].start()
+    for t in threads:
+      t.join()
+      bar.next()
+    bar.finish()
+
+    # Check which files had headers used, report on the results.
+    matches = Counter()
+    self._files = []
+    file_ids = []
+    for i, (infile, f) in enumerate(expanded_infiles):
+      fkey = f
+      if fkey.startswith('/'):
+        fkey = '__ROOT__'+fkey
+      if is_valid[i]:
+        matches[infile] += 1
+        filenum = len(self._files)
+        self._files.append(f)
+        file_ids.extend([filenum]*(len(headers[i])//72))
+        header_cache[fkey] = headers[i]
+      else:
         matches[infile] += 0
-        continue
-      matches[infile] += 1
 
-      # Read the headers from the file(s) and store the info in the table.
-      filenum = len(self._files)
-      self._files.append(f)
-      if fkey not in header_cache:
-        from fstd2nc.extra import all_params
-        with open(f,'rb') as funit:
-          h = all_params(funit)
-
-        # Encode the keys without the file index info.
-        h['key'] >>= 10
-        header_cache[fkey] = h
-      h = header_cache[fkey]
-      # The file info will be an index into a separate file list.
-      h['file_id'] = np.empty(len(h['nomvar']), dtype='int32')
-      h['file_id'][:] = filenum
-
-      headers.append(h)
+    # Decode all the headers
+    headers = [h for h in headers if h is not None]
+    if len(headers) > 0:
+      headers = np.concatenate(headers)
+      headers = decode_headers(headers)
+      headers['file_id'] = np.array(file_ids, dtype='int32')
+      # Encode the keys without the file index info.
+      headers['key'] >>= 10
 
     # Check if the input entries actually matched anything.
     for infile, count in matches.items():
@@ -475,7 +498,7 @@ class BufferBase (object):
         else:
           warn(_("Problem with input file '%s'")%infile)
 
-    nfiles = len(headers)
+    nfiles = len(self._files)
     if nfiles == 0:
       error(_("no input files found!"))
     elif nfiles > 10:
@@ -483,10 +506,8 @@ class BufferBase (object):
       _pandas_needed = True
     info(_("Found %d RPN input file(s)"%nfiles))
 
-    self._headers = {}
-    for key in headers[0].keys():
-      self._headers[key] = np.ma.concatenate([headers[i][key] for i in range(nfiles)])
-    self._nrecs = len(self._headers[key])
+    self._headers = headers
+    self._nrecs = len(headers['nomvar'])
 
     # Find all unique meta (coordinate) records, and link a subset of files
     # that provide all unique metadata records.

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -338,7 +338,7 @@ class ExternInput (BufferBase):
     rmn.fstcloseall(iun)
 
     # Initialize the Buffer object with this info.
-    b = cls(gridfile, header_cache={'__ROOT__'+gridfile:headers}, **kwargs)
+    b = cls(gridfile, _headers=headers, **kwargs)
     b._grid_tmpdir = grid_tmpdir  # Save tmpdir until cleanup.
 
     # Save the dataframe for reference.


### PR DESCRIPTION
When scanning for record headers from multiple input files, use multiple processes to speed it up.  This gives a significant speedup on GPFS systems (can check a hundred input files in a few seconds).

This update does not change the data conversion step, which still works serially at the moment.