### PR TITLE
Fix for cases when get_crs returns None

### DIFF
--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -502,7 +502,10 @@ class ExternOutput (BufferBase):
 
     # Add CRS information (used by some Python modules).
     try:
-      out.attrs['_CRS'] = get_crs(out).to_wkt()
+      crs = get_crs(out)
+      if crs is None:
+        return out
+      out.attrs['_CRS'] = crs.to_wkt()
     except ModuleNotFoundError:
       warn(_('Cartopy not found.  Unable to add _CRS attribute.'))
     return out

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -503,9 +503,8 @@ class ExternOutput (BufferBase):
     # Add CRS information (used by some Python modules).
     try:
       crs = get_crs(out)
-      if crs is None:
-        return out
-      out.attrs['_CRS'] = crs.to_wkt()
+      if crs is not None:
+        out.attrs['_CRS'] = crs.to_wkt()
     except ModuleNotFoundError:
       warn(_('Cartopy not found.  Unable to add _CRS attribute.'))
     return out

--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -503,10 +503,11 @@ class ExternOutput (BufferBase):
     # Add CRS information (used by some Python modules).
     try:
       crs = get_crs(out)
-      if crs is not None:
-        out.attrs['_CRS'] = crs.to_wkt()
     except ModuleNotFoundError:
       warn(_('Cartopy not found.  Unable to add _CRS attribute.'))
+    else:
+      if crs is not None:
+        out.attrs['_CRS'] = crs.to_wkt()
     return out
 
   def to_xarray_list (self, fused=False):


### PR DESCRIPTION
Simple bug a stumbled upon when testing for #82 .

`get_crs` may return `None` if there is a number of grid mapping different than 1, or if the grid mapping is not understood.
It than failed because of the `.to_wkt()` called on the None object.

My toy dataset has two "rotated_pole2" for example.