### PR TITLE
Add lake and river surface types

### DIFF
--- a/fstd2nc/mixins/sfc_codes.py
+++ b/fstd2nc/mixins/sfc_codes.py
@@ -41,6 +41,8 @@ sfc_agg_codes = {
   4: "lake_ice_or_sea_ice", # (lake ice, sea ice))
   5: "all_area_types", # (aggregated)
   6: "urban",          # (urban)
+  7: "lake_and_inland_sea", # (lake)
+  8: "river"           # (rivers)
 }
 reverse_sfc_agg_codes = dict((v,k) for k,v in sfc_agg_codes.items())
 # List of "aggregated" variables in rpnphy


### PR DESCRIPTION
This PR adds the "lakes" and "river" surface types, as defined in SPS (see [`sfc_busmod.F90`](https://github.com/ECCC-ASTD-MRD/sps/blob/3cde7e8aa9e0b78f65da93da45fe55ad351bb07b/src/rpnphy/src/surface/sfcbus_mod.F90#L538-L539)).  "river" is yet unused in SPS, but already defined. The "lake" level is also defined (with the same code) in the CRCM. 

The cf convention only recently added these area types, but they fit pretty well with what SPS does. 