### PR TITLE
Minor fixes for xarray

### DIFF
--- a/fstd2nc/mixins/extern.py
+++ b/fstd2nc/mixins/extern.py
@@ -716,7 +716,7 @@ class ExternOutput (BufferBase):
     # Collect dimensions and coordinates into a separate structure.
     dims = {}
     coords = {}
-    for dimname,dimsize in ds.dims.items():
+    for dimname,dimsize in ds.sizes.items():
       if dimname in ds.variables:
         dims[dimname] = _axis_type(dimname,dict(ds[dimname].attrs),np.array(ds[dimname]))
       else:

--- a/fstd2nc/mixins/xycoords.py
+++ b/fstd2nc/mixins/xycoords.py
@@ -1229,7 +1229,13 @@ class XYCoords (BufferBase):
         # Do in loop, to handle case where have multiple grid mappings
         # separated by spaces (e.g. for subgrids).
         for g in var.atts['grid_mapping'].split():
-          projection_table[g] = None
+          # grid mapping might be hiding in coordinates in some setups
+          for coord in var.atts.get('coordinates', []):
+            if g == coord.name:
+              projection_table[g] = coord
+              break
+          else:
+            projection_table[g] = None
     for var in self._varlist:
       if var.name in projection_table.keys():
         projection_table[var.name] = var


### PR DESCRIPTION
These are two small fixes for xarray:

- Allow grid mappings hiding in the coordinates, as I had in issue #105. I know this is not pure CF conventions, but I find having grid mappings in coordinates is so much more convenient. But I could also simply remember to downgrade the variables before calling `to_fstd` if you don't want this "hack" here.
- Change iterator `ds.dims.items()` to `ds.sizes.items()`. The former will be removed in the near future and a warning is emitted in recent xarrays. The latter exists at least since the lowest supported xarray version (I tested), so the change should be imperceptible.
