### PR TITLE
Allow pathlib Paths in to_fstd

### DIFF
--- a/fstd2nc/mixins/fstd.py
+++ b/fstd2nc/mixins/fstd.py
@@ -347,7 +347,7 @@ class FSTD (BufferBase):
     import rpnpy.librmn.all as rmn
     import numpy as np
     if exists(filename) and not append and not rewrite: remove(filename)
-    outfile = rmn.fstopenall(filename, rmn.FST_RW)
+    outfile = rmn.fstopenall(str(filename), rmn.FST_RW)
     for i in np.where(self._headers['selected'] | self._headers['ismeta'])[0]:
       rec = self._fstluk(i)
       # Ensure data is Fortran-contiguous for librmn.


### PR DESCRIPTION
This explicitly casts the `filename` passed to `to_fstd` so that non-string objects can be passed, such as `pathlib.Path`. These `Path` objects are usually well supported in other similar functions (like `to_netcdf` or `to_zarr`), so I guessed it could be the case here too ?

Seing how the existence of the file is tested just above, I assumed that the function was meant to receive a simple single path, so that the cast to string made sense in all cases.