### PR TITLE
Add TGRD (SVS1 from sps 6.3) to soil depth vars

### DIFF
--- a/fstd2nc/mixins/sfc_codes.py
+++ b/fstd2nc/mixins/sfc_codes.py
@@ -60,7 +60,7 @@ sfc_agg_nomvars = (
 # List of variables that use a soil depth coordinate.
 # For output of SPS.
 default_soil_depths = "0.05,0.1,0.2,0.4,1.0,2.0,3.0"
-soil_depth_nomvars = ('WSOL', 'ISOL')
+soil_depth_nomvars = ('WSOL', 'ISOL', 'TGRD')
 
 class Sfc_Codes (BufferBase):
   @classmethod


### PR DESCRIPTION
As title says, this adds TGRD to the list of "soil depth variables". TGRD is the ground temperature profile added in SVS1, as available in SPS 6.3a15 : 

https://github.com/ECCC-ASTD-MRD/sps/blob/725ecbd847987f4a9634a01b617ed722442a341d/src/rpnphy/src/surface/sfc_businit.F90#L469

Would it be interesting to make `soil_depth_nomvars` an option ? So it can be modified at run/call time. Currently, I monkeypatch fstd2nc upon import.